### PR TITLE
feat: override UW and HighDelay pose estimators to use fixed covariances

### DIFF
--- a/pose_estimation.orogen
+++ b/pose_estimation.orogen
@@ -348,5 +348,5 @@ task_context "HighDelayPoseEstimatorFixedCovariance" do
     needs_configuration
 
     # XY samples covariance matrix
-    property "cov_xy_samples", "/base/Matrix3d"
+    property "cov_xy_samples", "/base/Matrix2d"
 end

--- a/pose_estimation.orogen
+++ b/pose_estimation.orogen
@@ -332,3 +332,21 @@ task_context "OrientationInitialization" do
 
     periodic 0.01
 end
+
+task_context "UWPoseEstimatorFixedCovariance" do
+    subclasses "UWPoseEstimator"
+    needs_configuration
+
+    # Depth covariance element
+    property "cov_depth", "double"
+    # Orientation covariance matrix
+    property "cov_orientation", "/base/Matrix3d"
+end
+
+task_context "HighDelayPoseEstimatorFixedCovariance" do
+    subclasses "HighDelayPoseEstimator"
+    needs_configuration
+
+    # XY samples covariance matrix
+    property "cov_xy_samples", "/base/Matrix3d"
+end

--- a/tasks/HighDelayPoseEstimatorFixedCovariance.cpp
+++ b/tasks/HighDelayPoseEstimatorFixedCovariance.cpp
@@ -1,0 +1,98 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "HighDelayPoseEstimatorFixedCovariance.hpp"
+
+using namespace pose_estimation;
+
+HighDelayPoseEstimatorFixedCovariance::HighDelayPoseEstimatorFixedCovariance(
+    std::string const& name)
+    : HighDelayPoseEstimatorFixedCovarianceBase(name)
+{
+}
+
+HighDelayPoseEstimatorFixedCovariance::~HighDelayPoseEstimatorFixedCovariance()
+{
+}
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See HighDelayPoseEstimatorFixedCovariance.hpp for more
+// detailed documentation about them.
+
+bool HighDelayPoseEstimatorFixedCovariance::configureHook()
+{
+    if (!HighDelayPoseEstimatorFixedCovarianceBase::configureHook())
+        return false;
+
+    m_cov_xy_samples = _cov_xy_samples.get();
+    return true;
+}
+
+bool HighDelayPoseEstimatorFixedCovariance::startHook()
+{
+    if (!HighDelayPoseEstimatorFixedCovarianceBase::startHook())
+        return false;
+    return true;
+}
+
+void HighDelayPoseEstimatorFixedCovariance::updateHook()
+{
+    HighDelayPoseEstimatorFixedCovarianceBase::updateHook();
+}
+
+void HighDelayPoseEstimatorFixedCovariance::xy_position_samplesTransformerCallback(
+    const base::Time& ts,
+    const ::base::samples::RigidBodyState& xy_position_samples_sample)
+{
+    if (!pose_estimator->isInitialized()) {
+        RTT::log(RTT::Error)
+            << "Waiting for pose samples, filter has not jet been initialized"
+            << RTT::endlog();
+        return;
+    }
+
+    // receive sensor to body transformation
+    Eigen::Affine3d sensor_map2target_map;
+    if (!getSensorInBodyPose(_xy_map2target_map, ts, sensor_map2target_map))
+        return;
+
+    if (xy_position_samples_sample.position.block(0, 0, 2, 1).allFinite() &&
+        m_cov_xy_samples.block(0, 0, 2, 2).allFinite()) {
+        predictionStep(ts);
+        try {
+            // this transforms a position measurement expressed in a different map frame
+            // to a position expressed in the target map frame
+            Eigen::Vector3d transformed_position_sample =
+                sensor_map2target_map *
+                Eigen::Vector3d(xy_position_samples_sample.position.x(),
+                    xy_position_samples_sample.position.y(),
+                    0.0);
+
+            PoseUKF::XYMeasurement measurement;
+            measurement.mu = transformed_position_sample.block(0, 0, 2, 1);
+            measurement.cov = m_cov_xy_samples.block(0, 0, 2, 2);
+            pose_estimator->integrateMeasurement(measurement);
+        }
+        catch (const std::runtime_error& e) {
+            RTT::log(RTT::Error)
+                << "Failed to add delayed position measurement: " << e.what()
+                << RTT::endlog();
+        }
+    }
+    else
+        RTT::log(RTT::Error)
+            << "Delayed position measurement contains NaN's, it will be skipped!"
+            << RTT::endlog();
+}
+
+void HighDelayPoseEstimatorFixedCovariance::errorHook()
+{
+    HighDelayPoseEstimatorFixedCovarianceBase::errorHook();
+}
+void HighDelayPoseEstimatorFixedCovariance::stopHook()
+{
+    HighDelayPoseEstimatorFixedCovarianceBase::stopHook();
+}
+void HighDelayPoseEstimatorFixedCovariance::cleanupHook()
+{
+    HighDelayPoseEstimatorFixedCovarianceBase::cleanupHook();
+}

--- a/tasks/HighDelayPoseEstimatorFixedCovariance.hpp
+++ b/tasks/HighDelayPoseEstimatorFixedCovariance.hpp
@@ -1,0 +1,111 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef POSE_ESTIMATION_HIGHDELAYPOSEESTIMATORFIXEDCOVARIANCE_TASK_HPP
+#define POSE_ESTIMATION_HIGHDELAYPOSEESTIMATORFIXEDCOVARIANCE_TASK_HPP
+
+#include "pose_estimation/HighDelayPoseEstimatorFixedCovarianceBase.hpp"
+
+namespace pose_estimation {
+
+    /*! \class HighDelayPoseEstimatorFixedCovariance
+     * \brief The task context provides and requires services. It uses an ExecutionEngine
+     to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These
+     interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the
+     associated workflow.
+     *
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','pose_estimation::HighDelayPoseEstimatorFixedCovariance')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix
+     argument.
+     */
+    class HighDelayPoseEstimatorFixedCovariance
+        : public HighDelayPoseEstimatorFixedCovarianceBase {
+        friend class HighDelayPoseEstimatorFixedCovarianceBase;
+
+    protected:
+        base::Matrix3d m_cov_xy_samples;
+        void xy_position_samplesTransformerCallback(const base::Time& ts,
+            const ::base::samples::RigidBodyState& xy_position_samples_sample);
+
+    public:
+        /** TaskContext constructor for HighDelayPoseEstimatorFixedCovariance
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable via nameservices. \param initial_state The initial TaskState
+         * of the TaskContext. Default is Stopped state.
+         */
+        HighDelayPoseEstimatorFixedCovariance(
+            std::string const& name =
+                "pose_estimation::HighDelayPoseEstimatorFixedCovariance");
+
+        /** Default deconstructor of HighDelayPoseEstimatorFixedCovariance
+         */
+        ~HighDelayPoseEstimatorFixedCovariance();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states.
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif

--- a/tasks/HighDelayPoseEstimatorFixedCovariance.hpp
+++ b/tasks/HighDelayPoseEstimatorFixedCovariance.hpp
@@ -30,7 +30,7 @@ namespace pose_estimation {
         friend class HighDelayPoseEstimatorFixedCovarianceBase;
 
     protected:
-        base::Matrix3d m_cov_xy_samples;
+        base::Matrix2d m_cov_xy_samples;
         void xy_position_samplesTransformerCallback(const base::Time& ts,
             const ::base::samples::RigidBodyState& xy_position_samples_sample);
 

--- a/tasks/UWPoseEstimatorFixedCovariance.cpp
+++ b/tasks/UWPoseEstimatorFixedCovariance.cpp
@@ -1,0 +1,121 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "UWPoseEstimatorFixedCovariance.hpp"
+
+using namespace pose_estimation;
+
+UWPoseEstimatorFixedCovariance::UWPoseEstimatorFixedCovariance(std::string const& name)
+    : UWPoseEstimatorFixedCovarianceBase(name)
+{
+}
+
+UWPoseEstimatorFixedCovariance::~UWPoseEstimatorFixedCovariance()
+{
+}
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See UWPoseEstimatorFixedCovariance.hpp for more detailed
+// documentation about them.
+
+bool UWPoseEstimatorFixedCovariance::configureHook()
+{
+    if (!UWPoseEstimatorFixedCovarianceBase::configureHook())
+        return false;
+
+    m_cov_depth = _cov_depth.get();
+    m_cov_orientation = _cov_orientation.get();
+    return true;
+}
+bool UWPoseEstimatorFixedCovariance::startHook()
+{
+    if (!UWPoseEstimatorFixedCovarianceBase::startHook())
+        return false;
+    return true;
+}
+
+void UWPoseEstimatorFixedCovariance::updateHook()
+{
+    UWPoseEstimatorFixedCovarianceBase::updateHook();
+}
+
+void UWPoseEstimatorFixedCovariance::depth_samplesTransformerCallback(
+    const base::Time& ts,
+    const ::base::samples::RigidBodyState& depth_samples_sample)
+{
+    // receive sensor to body transformation
+    Eigen::Affine3d sensorInBody;
+    if (!getSensorInBodyPose(_pressure_sensor2body, ts, sensorInBody))
+        return;
+
+    PoseUKF::State current_state;
+    if (!base::isNaN(depth_samples_sample.position.z()) && !base::isNaN(m_cov_depth) &&
+        pose_estimator->getCurrentState(current_state)) {
+        predictionStep(ts);
+        try {
+            // apply sensorInBody transformation to measurement
+            Eigen::Matrix<double, 1, 1> depth;
+            depth << depth_samples_sample.position.z() -
+                         (current_state.orientation * sensorInBody.translation()).z();
+
+            PoseUKF::ZMeasurement measurement;
+            measurement.mu = depth;
+            measurement.cov(0, 0) = m_cov_depth;
+            pose_estimator->integrateMeasurement(measurement);
+        }
+        catch (const std::runtime_error& e) {
+            RTT::log(RTT::Error)
+                << "Failed to add depth measurement: " << e.what() << RTT::endlog();
+        }
+    }
+    else
+        RTT::log(RTT::Error) << "Depth measurement contains NaN's, it will be skipped!"
+                             << RTT::endlog();
+}
+
+void UWPoseEstimatorFixedCovariance::orientation_samplesTransformerCallback(
+    const base::Time& ts,
+    const ::base::samples::RigidBodyState& orientation_samples_sample)
+{
+    // receive sensor to body transformation
+    Eigen::Affine3d sensorInBody;
+    if (!getSensorInBodyPose(_imu2body, ts, sensorInBody))
+        return;
+
+    if (orientation_samples_sample.hasValidOrientation() &&
+        base::samples::RigidBodyState::isValidCovariance(m_cov_orientation)) {
+        predictionStep(ts);
+        try {
+            // apply sensorInBody transformation to measurement
+            Eigen::Quaterniond transformed_orientation(
+                (orientation_samples_sample.orientation * sensorInBody.inverse())
+                    .linear());
+
+            PoseUKF::OrientationMeasurement measurement;
+            measurement.mu = MTK::SO3<double>::log(transformed_orientation);
+            measurement.cov = sensorInBody.rotation() * m_cov_orientation *
+                              sensorInBody.rotation().transpose();
+            pose_estimator->integrateMeasurement(measurement);
+        }
+        catch (const std::runtime_error& e) {
+            RTT::log(RTT::Error)
+                << "Failed to add orientation measurement: " << e.what() << RTT::endlog();
+        }
+    }
+    else
+        RTT::log(RTT::Error)
+            << "Orientation measurement contains NaN's, it will be skipped!"
+            << RTT::endlog();
+}
+
+void UWPoseEstimatorFixedCovariance::errorHook()
+{
+    UWPoseEstimatorFixedCovarianceBase::errorHook();
+}
+void UWPoseEstimatorFixedCovariance::stopHook()
+{
+    UWPoseEstimatorFixedCovarianceBase::stopHook();
+}
+void UWPoseEstimatorFixedCovariance::cleanupHook()
+{
+    UWPoseEstimatorFixedCovarianceBase::cleanupHook();
+}

--- a/tasks/UWPoseEstimatorFixedCovariance.hpp
+++ b/tasks/UWPoseEstimatorFixedCovariance.hpp
@@ -1,0 +1,114 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef POSE_ESTIMATION_UWPOSEESTIMATORFIXEDCOVARIANCE_TASK_HPP
+#define POSE_ESTIMATION_UWPOSEESTIMATORFIXEDCOVARIANCE_TASK_HPP
+
+#include "pose_estimation/UWPoseEstimatorFixedCovarianceBase.hpp"
+
+namespace pose_estimation {
+
+    /*! \class UWPoseEstimatorFixedCovariance
+     * \brief The task context provides and requires services. It uses an ExecutionEngine
+     to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These
+     interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the
+     associated workflow.
+     *
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','pose_estimation::UWPoseEstimatorFixedCovariance')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix
+     argument.
+     */
+    class UWPoseEstimatorFixedCovariance : public UWPoseEstimatorFixedCovarianceBase {
+        friend class UWPoseEstimatorFixedCovarianceBase;
+
+    protected:
+        double m_cov_depth = 0;
+        base::Matrix3d m_cov_orientation;
+
+        void depth_samplesTransformerCallback(const base::Time& ts,
+            const ::base::samples::RigidBodyState& depth_samples_sample);
+
+        void orientation_samplesTransformerCallback(const base::Time& ts,
+            const ::base::samples::RigidBodyState& orientation_samples_sample);
+
+    public:
+        /** TaskContext constructor for UWPoseEstimatorFixedCovariance
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable via nameservices. \param initial_state The initial TaskState of
+         * the TaskContext. Default is Stopped state.
+         */
+        UWPoseEstimatorFixedCovariance(
+            std::string const& name = "pose_estimation::UWPoseEstimatorFixedCovariance");
+
+        /** Default deconstructor of UWPoseEstimatorFixedCovariance
+         */
+        ~UWPoseEstimatorFixedCovariance();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states.
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
This overrides the callbacks for xy_position, orientation and depth
samples. The new versions use a fixed covariance for all these methods.
Without this, it is troublesome to use some pose sources that dont
provide cov_position and cov_orientation, such as those that come from a
transformer and that do some transformations inside of them.
# How I did it
<!-- Explain a little bit of your implementation -->
Copied the same code used in the original tasks, but replaced any references to cov_orientation/cov_position to the ones that come from properties.
# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->
TBD
# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [x] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
